### PR TITLE
Fix Localstack Config To Match Upstream Release

### DIFF
--- a/clearflask-release/src/main/docker/compose/docker-compose.self-host.yml
+++ b/clearflask-release/src/main/docker/compose/docker-compose.self-host.yml
@@ -81,4 +81,4 @@ services:
       - FORCE_NONINTERACTIVE=true
       - DATA_DIR=/tmp/localstack/data
     volumes:
-      - ./data/localstack:/tmp/localstack
+      - ./data/localstack:/var/lib/localstack


### PR DESCRIPTION
Localstack/Localstack released v1 in or around December 2022, including a "minor" configuration change that silently breaks the current docker local dependency profile.  The smallest PR I will probably ever submit to any project makes the `localstack` container start again.

In lieu of a Unit Test on a 3rd-party dependency, see https://github.com/localstack/localstack/issues/6398 More specifically, the first bullet point under "How to Migrate".

