### PR TITLE
Preserve CSS class names for styling

### DIFF
--- a/clearflask-frontend/src/Main.tsx
+++ b/clearflask-frontend/src/Main.tsx
@@ -4,6 +4,7 @@ import loadable from '@loadable/component';
 import { createMuiTheme, NoSsr, Theme } from '@material-ui/core';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { MuiThemeProvider, StylesProvider } from '@material-ui/core/styles';
+import { generateClassName } from './common/util/classNameGenerator';
 import { ErrorBoundary } from '@sentry/react';
 import i18n from 'i18next';
 import { SnackbarProvider } from 'notistack';
@@ -166,7 +167,7 @@ class Main extends Component<Props> {
       <ErrorBoundary showDialog>
         <React.StrictMode>
           <I18nextProvider i18n={this.props.i18n}>
-            <StylesProvider injectFirst>
+            <StylesProvider injectFirst generateClassName={generateClassName}>
               <MuiThemeProvider theme={this.theme}>
                 <MuiSnackbarProvider notistackRef={notistackRef}>
                   <CssBaseline />

--- a/clearflask-frontend/src/app/AppThemeProvider.tsx
+++ b/clearflask-frontend/src/app/AppThemeProvider.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { createMuiTheme, CssBaseline, Theme } from '@material-ui/core';
 import { MuiThemeProvider, StylesProvider } from '@material-ui/core/styles';
+import { generateClassName } from '../common/util/classNameGenerator';
 import { Breakpoint } from '@material-ui/core/styles/createBreakpoints';
 import { ComponentsProps } from '@material-ui/core/styles/props';
 import React, { Component } from 'react';
@@ -162,7 +163,7 @@ class AppThemeProvider extends Component<Props> {
     }
 
     return (
-      <StylesProvider injectFirst>
+      <StylesProvider injectFirst generateClassName={generateClassName}>
         <MuiThemeProvider theme={theme}>
           {!this.props.supressCssBaseline && (<CssBaseline />)}
           <div style={{

--- a/clearflask-frontend/src/common/util/classNameGenerator.ts
+++ b/clearflask-frontend/src/common/util/classNameGenerator.ts
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2019-2022 Matus Faro <matus@smotana.com>
+// SPDX-License-Identifier: Apache-2.0
+import { createGenerateClassName } from '@material-ui/core/styles';
+
+/**
+ * Creates a custom class name generator that preserves readable CSS class names.
+ *
+ * By default, MUI/JSS obfuscates class names in production (e.g., 'jss1', 'jss2').
+ * This configuration preserves semantic class names (e.g., 'MuiButton-root', 'makeStyles-header-1')
+ * so customers can target them in their custom CSS.
+ *
+ * @param seed Optional seed to avoid class name collisions when multiple style providers exist
+ */
+export const createClassNameGenerator = (seed?: string) => createGenerateClassName({
+  // Disable global class name obfuscation - keeps names like 'MuiButton-root'
+  disableGlobal: false,
+  // Use 'cf' (ClearFlask) prefix for makeStyles/withStyles generated classes
+  // This makes classes like 'cf-ComponentName-ruleName-123' instead of 'jss123'
+  productionPrefix: 'cf',
+  // Seed to avoid collisions between different StylesProvider instances
+  seed: seed || '',
+});
+
+/**
+ * Shared class name generator instance for the main application.
+ * Using a single instance ensures consistent class naming across components.
+ */
+export const generateClassName = createClassNameGenerator();

--- a/clearflask-frontend/src/connect/renderer.ts
+++ b/clearflask-frontend/src/connect/renderer.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ChunkExtractor } from '@loadable/server';
 import { ServerStyleSheets } from '@material-ui/core';
+import { generateClassName } from '../common/util/classNameGenerator';
 import htmlparser from 'cheerio';
 import { Handler } from 'express';
 import fs from 'fs';
@@ -113,7 +114,7 @@ export default function render(): Handler {
                 publicPath: (connectConfig.parentDomain !== 'clearflask.com')
                   ? '/' : undefined,
               }),
-              muiSheets: new ServerStyleSheets(),
+              muiSheets: new ServerStyleSheets({ generateClassName }),
               renderedScreen: '',
             };
             try {


### PR DESCRIPTION
Configure MUI/JSS to generate predictable, readable CSS class names instead of obfuscated ones (jss1, jss2, etc.). This allows customers to reliably target ClearFlask elements in their custom CSS.

- Add classNameGenerator utility with 'cf' prefix for makeStyles/withStyles
- Update StylesProvider in Main.tsx and AppThemeProvider.tsx
- Configure ServerStyleSheets for SSR compatibility