### PR TITLE
fix(i18n): stop trapping users on the lol contribute locale

### DIFF
--- a/clearflask-frontend/src/LanguageSelect.tsx
+++ b/clearflask-frontend/src/LanguageSelect.tsx
@@ -128,6 +128,11 @@ export const CrowdInInlineEditing = () => {
     const [contributeSelected, setContributeSelected] = useState<boolean>();
     const {i18n} = useTranslation();
     useEffect(() => {
+        // Initialise from the current language, not just from future
+        // languageChanged events. Without this, refreshing a page that's
+        // already in contribute mode (lol) skips the dialog and jipt.js
+        // never loads, so the user just sees raw crwdns###:0 markers.
+        setContributeSelected(!!supportedLanguages.find(l => l.code === i18n.language)?.isContribute);
         i18n.on('languageChanged', lng => {
             setContributeSelected(!!supportedLanguages.find(l => l.code === lng)?.isContribute);
         });

--- a/clearflask-frontend/src/i18n-csr.ts
+++ b/clearflask-frontend/src/i18n-csr.ts
@@ -4,7 +4,7 @@ import i18n from 'i18next';
 import BrowserLanguageDetector from 'i18next-browser-languagedetector';
 import Cookies from './common/util/cookies';
 import { htmlDataRetrieve } from './common/util/htmlData';
-import { getI18n as getI18nGeneric, LANGUAGE_SELECTION_COOKIE_NAME, setLangIsUserSelected } from './i18n';
+import { getI18n as getI18nGeneric, LANGUAGE_SELECTION_COOKIE_NAME, setLangIsUserSelected, supportedLanguages } from './i18n';
 
 var instance: typeof i18n | undefined;
 export const getI18n = () => {
@@ -44,7 +44,34 @@ export const getI18n = () => {
   return instance;
 };
 
+const isContributeOnlyCode = (code?: string): boolean =>
+  !!code && !!supportedLanguages.find(l => l.code === code)?.isContribute;
+
+// Contribute-only locales (currently just "lol", the Crowdin in-context-editor
+// slot) are persisted in sessionStorage instead of the long-lived cookie.
+// Cookie semantics would trap the user: closing the contribute dialog or the
+// browser would leave the entire app rendered as crwdns###:0crwdne###:0
+// markers on every subsequent visit. sessionStorage is tab-scoped so it
+// survives in-tab navigations (so a translator can edit multi-page strings)
+// but resets on tab close.
+const CONTRIBUTE_LANG_SESSION_KEY = 'cf-contribute-lang';
+
+const getSessionStorage = (): Storage | undefined => {
+  try {
+    return typeof window !== 'undefined' ? window.sessionStorage : undefined;
+  } catch (e) {
+    return undefined;
+  }
+};
+
 export const rememberUserSelection = (language?: string): void => {
+  const ss = getSessionStorage();
+  if (!!language && isContributeOnlyCode(language)) {
+    ss?.setItem(CONTRIBUTE_LANG_SESSION_KEY, language);
+    Cookies.getInstance().unset(LANGUAGE_SELECTION_COOKIE_NAME);
+    return;
+  }
+  ss?.removeItem(CONTRIBUTE_LANG_SESSION_KEY);
   if (!!language) {
     Cookies.getInstance().set(LANGUAGE_SELECTION_COOKIE_NAME, language, 365);
   } else {
@@ -52,9 +79,22 @@ export const rememberUserSelection = (language?: string): void => {
   }
 };
 export const getUserSelection = (): string | undefined => {
+  // In-tab contribute mode wins (only set during an active translate session).
+  const sessionLanguage = getSessionStorage()?.getItem(CONTRIBUTE_LANG_SESSION_KEY);
+  if (sessionLanguage && isContributeOnlyCode(sessionLanguage)) {
+    return sessionLanguage;
+  }
+
   const stored = Cookies.getInstance().get(LANGUAGE_SELECTION_COOKIE_NAME);
   // Legacy "zh" cookies were set when there was a single Chinese locale.
   // Map them to Chinese Simplified so returning users keep their language.
   if (stored === 'zh') return 'zh-CN';
+  // Recover users whose cookie was stuck on a contribute-only slot before the
+  // rememberUserSelection guard above was deployed: drop the cookie and let
+  // normal detection take over.
+  if (isContributeOnlyCode(stored)) {
+    Cookies.getInstance().unset(LANGUAGE_SELECTION_COOKIE_NAME);
+    return undefined;
+  }
   return stored;
 };

--- a/clearflask-frontend/src/i18n-ssr.ts
+++ b/clearflask-frontend/src/i18n-ssr.ts
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 import CountryLocaleMap from 'country-locale-map';
 import i18nMiddleware from 'i18next-http-middleware';
-import { defaultLanguage, getI18n as getI18nGeneric, LANGUAGE_SELECTION_COOKIE_NAME, setLangIsUserSelected, supportedLanguagesSet } from './i18n';
+import { defaultLanguage, getI18n as getI18nGeneric, LANGUAGE_SELECTION_COOKIE_NAME, setLangIsUserSelected, supportedLanguages, supportedLanguagesSet } from './i18n';
+
+const contributeOnlyCodes = new Set(supportedLanguages.filter(l => l.isContribute).map(l => l.code));
 
 export const getI18n = () => {
   var languageDetector = new i18nMiddleware.LanguageDetector();
@@ -13,6 +15,10 @@ export const getI18n = () => {
       // there was a single Chinese locale) map to Chinese Simplified.
       let cookieLanguage = req.cookies?.[LANGUAGE_SELECTION_COOKIE_NAME];
       if (cookieLanguage === 'zh') cookieLanguage = 'zh-CN';
+      // Drop stale cookies pointing at a contribute-only locale (e.g. "lol",
+      // the in-context-editor slot, which renders the entire app as
+      // crwdns###:0crwdne###:0 markers). The CSR layer also clears it.
+      if (cookieLanguage && contributeOnlyCodes.has(cookieLanguage)) cookieLanguage = undefined;
       if (cookieLanguage && supportedLanguagesSet.has(cookieLanguage)) {
         setLangIsUserSelected();
         return cookieLanguage;


### PR DESCRIPTION
## Summary
Refreshing a page that's already on `lol` (the Crowdin in-context-editor slot) never re-loads jipt.js, so the user sees raw `crwdns###:0crwdne###:0` markers instead of clickable translation handles. And clicking "Help us translate" persists `x-cf-lang=lol` for 365 days, so closing the dialog or the browser leaves you on that broken-looking page on every subsequent visit.

Three changes:

1. **CSR** (\`i18n-csr.ts\`) — contribute-only locales now persist in `sessionStorage` instead of the long-lived cookie. Multi-page translation in the same tab still works (sessionStorage survives navigation); tab close auto-recovers. Stale `lol` cookies from before this change are dropped on read so existing trapped users self-heal.
2. **SSR** (\`i18n-ssr.ts\`) — the cookie reader treats `lol` as undefined and falls through to `Accept-Language`. Contribute users get a one-frame default-language paint before CSR rehydrates to `lol` — acceptable for translators only.
3. **\`CrowdInInlineEditing\`** — was only listening for *future* `languageChanged` events, so a refresh that started in `lol` never opened the contribute dialog or loaded jipt.js. Now initialises from the current language at mount too.

## Test plan
- [ ] Click "Help us translate" → dialog appears → "Open" → jipt.js loads, crwdns markers become editable.
- [ ] Navigate to /pricing within the same tab → still in lol, jipt.js still active.
- [ ] Refresh → dialog appears again, "Open" → jipt.js reloads, editor works.
- [ ] Close the tab, reopen `clearflask.com` → no `lol` cookie, no `lol` sessionStorage → renders the user's normal language.
- [ ] Existing user with stale `x-cf-lang=lol` cookie visits → cookie dropped on first read → renders normal language → no more crwdns markers.