### PR TITLE
fix(logging): suppress noisy Hikari stale-connection WARN emails

### DIFF
--- a/clearflask-server/src/main/resources/deploy/cfkb-ami-create.sh
+++ b/clearflask-server/src/main/resources/deploy/cfkb-ami-create.sh
@@ -381,7 +381,7 @@ sudo tee /usr/share/tomcat/webapps/100killbill/ROOT/WEB-INF/classes/logback.xml 
             <evaluator>
                 <matcher>
                     <Name>regex</Name>
-                    <regex>.*(falling back to SQLDialect|The scratchDir you specified|Unable to find the JRuby bundle|Timed out while shutting down [\w-]+(-service)?(:[\w-]+)?(-events)? queue|doesn't have a default payment method).*</regex>
+                    <regex>.*(falling back to SQLDialect|The scratchDir you specified|Unable to find the JRuby bundle|Timed out while shutting down [\w-]+(-service)?(:[\w-]+)?(-events)? queue|doesn't have a default payment method|Failed to validate connection .* (Connection\.setNetworkTimeout cannot be called on a closed connection|Possibly consider using a shorter maxLifetime value)).*</regex>
                 </matcher>
                 <expression>regex.matches(formattedMessage)</expression>
             </evaluator>

--- a/clearflask-server/src/main/resources/deploy/kb-ami-create.sh
+++ b/clearflask-server/src/main/resources/deploy/kb-ami-create.sh
@@ -286,7 +286,7 @@ sudo tee /usr/share/tomcat/webapps/killbill/ROOT/WEB-INF/classes/logback.xml <<"
             <evaluator>
                 <matcher>
                     <Name>regex</Name>
-                    <regex>.*(falling back to SQLDialect|The scratchDir you specified|Unable to find the JRuby bundle|Timed out while shutting down [\w-]+(-service)?(:[\w-]+)?(-events)? queue|doesn't have a default payment method).*</regex>
+                    <regex>.*(falling back to SQLDialect|The scratchDir you specified|Unable to find the JRuby bundle|Timed out while shutting down [\w-]+(-service)?(:[\w-]+)?(-events)? queue|doesn't have a default payment method|Failed to validate connection .* (Connection\.setNetworkTimeout cannot be called on a closed connection|Possibly consider using a shorter maxLifetime value)).*</regex>
                 </matcher>
                 <expression>regex.matches(formattedMessage)</expression>
             </evaluator>


### PR DESCRIPTION
## Summary
Hikari's pool routinely picks up connections the DB closed mid-idle, fails to set a network timeout on the now-closed socket, logs a WARN, and recycles. The pool keeps working but the WARN bypasses the email filter and pages ops@. Extend the existing regex deny-filter to drop that family.

Pattern added: \`Failed to validate connection ... (Connection.setNetworkTimeout cannot be called on a closed connection | Possibly consider using a shorter maxLifetime value)\`

Other \`Failed to validate connection\` variants (real auth/connectivity failures) and the rest of HikariCP's WARNs continue to flow through.

## Note
Takes effect on next AMI rebuild + instance refresh. For immediate relief on the running cf-kb instance, the same line can be patched live in \`/usr/share/tomcat/webapps/100killbill/ROOT/WEB-INF/classes/logback.xml\` — logback re-scans every 60s.