### PR TITLE
fix: Recreate missing built-in statuses when re-enabling roadmap/feedback

### DIFF
--- a/clearflask-frontend/src/common/config/template/feedback.ts
+++ b/clearflask-frontend/src/common/config/template/feedback.ts
@@ -76,6 +76,28 @@ export async function feedbackOn(this: Templater, pageType: 'off' | 'feedback' |
     ]);
 
     feedback = (await this.feedbackGet())!;
+  } else {
+    // Category exists - check if built-in statuses are missing and recreate them
+    const categoryIndex = feedback.categoryAndIndex.index;
+    const workflowProp = this._get<ConfigEditor.ArrayProperty>(['content', 'categories', categoryIndex, 'workflow', 'statuses']);
+
+    // Check and recreate missing accepted status
+    if (!feedback.statusIdAccepted) {
+      const statusIdAccepted = FeedbackStatusAcceptedPrefix + randomUuid();
+      workflowProp.insert().setRaw(Admin.IdeaStatusToJSON({
+        name: T<'app'>('accepted'),
+        nextStatusIds: [],
+        color: this.workflowColorComplete,
+        statusId: statusIdAccepted,
+        disableFunding: false,
+        disableExpressions: false,
+        disableVoting: false,
+        disableComments: false,
+        disableIdeaEdits: false
+      }));
+
+      feedback = (await this.feedbackGet())!;
+    }
   }
 
   // Create/modify page


### PR DESCRIPTION
Fixes #145

When users delete built-in statuses (like "completed" in roadmap or "accepted" in feedback) and then re-enable the feature, the statuses were not being recreated. This breaks functionality like announcement management which depends on specific status ID prefixes.

## Changes
- Modified roadmapOn() to check for and recreate missing built-in statuses (backlog, completed, cancelled) when category already exists
- Modified feedbackOn() to check for and recreate missing "accepted" status when category already exists
- Ensures status IDs use proper prefixes for system recognition

Generated with [Claude Code](https://claude.ai/code)